### PR TITLE
feat: add auth scaffolding to modules

### DIFF
--- a/modules/analytics/README.md
+++ b/modules/analytics/README.md
@@ -1,0 +1,7 @@
+# Módulo Analytics
+
+Permisos mínimos requeridos:
+- `analytics.view`
+- `analytics.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/analytics/config.php
+++ b/modules/analytics/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Analytics',
+        'permissions' => ['analytics.view', 'analytics.edit']
+    ]
+];

--- a/modules/analytics/controller.php
+++ b/modules/analytics/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Analytics (AI) module API controller
+/**
+ * Controlador API del módulo Analytics
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['analytics.view', 'analytics.edit'],
+        'user'  => ['analytics.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/analytics/index.php
+++ b/modules/analytics/index.php
@@ -1,5 +1,31 @@
 <?php
-// Analytics (AI) module main view
+/**
+ * Módulo Analytics - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['analytics.view', 'analytics.edit'],
+        'user'  => ['analytics.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/analytics/modals.php
+++ b/modules/analytics/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Analytics
+?>

--- a/modules/chat/README.md
+++ b/modules/chat/README.md
@@ -1,0 +1,7 @@
+# Módulo Chat
+
+Permisos mínimos requeridos:
+- `chat.view`
+- `chat.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/chat/config.php
+++ b/modules/chat/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Chat',
+        'permissions' => ['chat.view', 'chat.edit']
+    ]
+];

--- a/modules/chat/controller.php
+++ b/modules/chat/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Chat module API controller
+/**
+ * Controlador API del módulo Chat
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['chat.view', 'chat.edit'],
+        'user'  => ['chat.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/chat/index.php
+++ b/modules/chat/index.php
@@ -1,5 +1,31 @@
 <?php
-// Chat module main view
+/**
+ * Módulo Chat - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['chat.view', 'chat.edit'],
+        'user'  => ['chat.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/chat/modals.php
+++ b/modules/chat/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Chat
+?>

--- a/modules/cleaning/README.md
+++ b/modules/cleaning/README.md
@@ -1,0 +1,7 @@
+# Módulo Cleaning
+
+Permisos mínimos requeridos:
+- `cleaning.view`
+- `cleaning.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/cleaning/config.php
+++ b/modules/cleaning/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Cleaning',
+        'permissions' => ['cleaning.view', 'cleaning.edit']
+    ]
+];

--- a/modules/cleaning/controller.php
+++ b/modules/cleaning/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Cleaning module API controller
+/**
+ * Controlador API del módulo Cleaning
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['cleaning.view', 'cleaning.edit'],
+        'user'  => ['cleaning.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/cleaning/index.php
+++ b/modules/cleaning/index.php
@@ -1,5 +1,31 @@
 <?php
-// Cleaning module main view
+/**
+ * Módulo Cleaning - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['cleaning.view', 'cleaning.edit'],
+        'user'  => ['cleaning.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/cleaning/modals.php
+++ b/modules/cleaning/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Cleaning
+?>

--- a/modules/crm/README.md
+++ b/modules/crm/README.md
@@ -1,0 +1,7 @@
+# Módulo Crm
+
+Permisos mínimos requeridos:
+- `crm.view`
+- `crm.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/crm/config.php
+++ b/modules/crm/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Crm',
+        'permissions' => ['crm.view', 'crm.edit']
+    ]
+];

--- a/modules/crm/controller.php
+++ b/modules/crm/controller.php
@@ -1,5 +1,41 @@
 <?php
-// CRM module API controller
+/**
+ * Controlador API del módulo Crm
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['crm.view', 'crm.edit'],
+        'user'  => ['crm.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/crm/index.php
+++ b/modules/crm/index.php
@@ -1,5 +1,31 @@
 <?php
-// CRM module main view
+/**
+ * Módulo Crm - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['crm.view', 'crm.edit'],
+        'user'  => ['crm.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/crm/modals.php
+++ b/modules/crm/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Crm
+?>

--- a/modules/expenses/README.md
+++ b/modules/expenses/README.md
@@ -288,3 +288,7 @@ mysqldump -u user -p database_name providers expenses expense_payments credit_no
 **Compatible con**: Sistema SaaS Indice v2.0+
 
 Para soporte técnico o nuevas funcionalidades, consultar la documentación del sistema SaaS principal.
+
+---
+
+Para más información sobre roles y permisos, consulta [docs/roles_permisos.md](../../docs/roles_permisos.md).

--- a/modules/forms/README.md
+++ b/modules/forms/README.md
@@ -1,0 +1,7 @@
+# Módulo Forms
+
+Permisos mínimos requeridos:
+- `forms.view`
+- `forms.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/forms/config.php
+++ b/modules/forms/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Forms',
+        'permissions' => ['forms.view', 'forms.edit']
+    ]
+];

--- a/modules/forms/controller.php
+++ b/modules/forms/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Forms module API controller
+/**
+ * Controlador API del módulo Forms
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['forms.view', 'forms.edit'],
+        'user'  => ['forms.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/forms/index.php
+++ b/modules/forms/index.php
@@ -1,5 +1,31 @@
 <?php
-// Forms module main view
+/**
+ * Módulo Forms - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['forms.view', 'forms.edit'],
+        'user'  => ['forms.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/forms/modals.php
+++ b/modules/forms/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Forms
+?>

--- a/modules/human-resources/README.md
+++ b/modules/human-resources/README.md
@@ -269,3 +269,7 @@ El módulo sigue el **patrón establecido por el módulo de gastos**:
 **Desarrollado por**: GitHub Copilot + Equipo Indice SaaS  
 **Fecha**: 7 de agosto de 2025  
 **Versión**: 1.0.0 (Base funcional)
+
+---
+
+Para más información sobre roles y permisos, consulta [docs/roles_permisos.md](../../docs/roles_permisos.md).

--- a/modules/inventory/README.md
+++ b/modules/inventory/README.md
@@ -1,0 +1,7 @@
+# Módulo Inventory
+
+Permisos mínimos requeridos:
+- `inventory.view`
+- `inventory.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/inventory/config.php
+++ b/modules/inventory/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Inventory',
+        'permissions' => ['inventory.view', 'inventory.edit']
+    ]
+];

--- a/modules/inventory/controller.php
+++ b/modules/inventory/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Inventory module API controller
+/**
+ * Controlador API del módulo Inventory
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['inventory.view', 'inventory.edit'],
+        'user'  => ['inventory.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/inventory/index.php
+++ b/modules/inventory/index.php
@@ -1,5 +1,31 @@
 <?php
-// Inventory module main view
+/**
+ * Módulo Inventory - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['inventory.view', 'inventory.edit'],
+        'user'  => ['inventory.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/inventory/modals.php
+++ b/modules/inventory/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Inventory
+?>

--- a/modules/invoicing/README.md
+++ b/modules/invoicing/README.md
@@ -1,0 +1,7 @@
+# Módulo Invoicing
+
+Permisos mínimos requeridos:
+- `invoicing.view`
+- `invoicing.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/invoicing/config.php
+++ b/modules/invoicing/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Invoicing',
+        'permissions' => ['invoicing.view', 'invoicing.edit']
+    ]
+];

--- a/modules/invoicing/controller.php
+++ b/modules/invoicing/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Invoicing module API controller
+/**
+ * Controlador API del módulo Invoicing
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['invoicing.view', 'invoicing.edit'],
+        'user'  => ['invoicing.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/invoicing/index.php
+++ b/modules/invoicing/index.php
@@ -1,5 +1,31 @@
 <?php
-// Invoicing module main view
+/**
+ * Módulo Invoicing - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['invoicing.view', 'invoicing.edit'],
+        'user'  => ['invoicing.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/invoicing/modals.php
+++ b/modules/invoicing/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Invoicing
+?>

--- a/modules/kpis/README.md
+++ b/modules/kpis/README.md
@@ -1,0 +1,7 @@
+# Módulo Kpis
+
+Permisos mínimos requeridos:
+- `kpis.view`
+- `kpis.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/kpis/config.php
+++ b/modules/kpis/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Kpis',
+        'permissions' => ['kpis.view', 'kpis.edit']
+    ]
+];

--- a/modules/kpis/controller.php
+++ b/modules/kpis/controller.php
@@ -1,5 +1,41 @@
 <?php
-// KPIs module API controller
+/**
+ * Controlador API del módulo Kpis
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['kpis.view', 'kpis.edit'],
+        'user'  => ['kpis.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/kpis/index.php
+++ b/modules/kpis/index.php
@@ -1,5 +1,31 @@
 <?php
-// KPIs module main view
+/**
+ * Módulo Kpis - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['kpis.view', 'kpis.edit'],
+        'user'  => ['kpis.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/kpis/modals.php
+++ b/modules/kpis/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Kpis
+?>

--- a/modules/laundry/README.md
+++ b/modules/laundry/README.md
@@ -1,0 +1,7 @@
+# Módulo Laundry
+
+Permisos mínimos requeridos:
+- `laundry.view`
+- `laundry.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/laundry/config.php
+++ b/modules/laundry/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Laundry',
+        'permissions' => ['laundry.view', 'laundry.edit']
+    ]
+];

--- a/modules/laundry/controller.php
+++ b/modules/laundry/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Laundry module API controller
+/**
+ * Controlador API del módulo Laundry
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['laundry.view', 'laundry.edit'],
+        'user'  => ['laundry.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/laundry/index.php
+++ b/modules/laundry/index.php
@@ -1,5 +1,31 @@
 <?php
-// Laundry module main view
+/**
+ * Módulo Laundry - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['laundry.view', 'laundry.edit'],
+        'user'  => ['laundry.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/laundry/modals.php
+++ b/modules/laundry/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Laundry
+?>

--- a/modules/maintenance/README.md
+++ b/modules/maintenance/README.md
@@ -1,0 +1,7 @@
+# Módulo Maintenance
+
+Permisos mínimos requeridos:
+- `maintenance.view`
+- `maintenance.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/maintenance/config.php
+++ b/modules/maintenance/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Maintenance',
+        'permissions' => ['maintenance.view', 'maintenance.edit']
+    ]
+];

--- a/modules/maintenance/controller.php
+++ b/modules/maintenance/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Maintenance module API controller
+/**
+ * Controlador API del módulo Maintenance
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['maintenance.view', 'maintenance.edit'],
+        'user'  => ['maintenance.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/maintenance/index.php
+++ b/modules/maintenance/index.php
@@ -1,5 +1,31 @@
 <?php
-// Maintenance module main view
+/**
+ * Módulo Maintenance - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['maintenance.view', 'maintenance.edit'],
+        'user'  => ['maintenance.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/minutes/README.md
+++ b/modules/minutes/README.md
@@ -1,0 +1,7 @@
+# Módulo Minutes
+
+Permisos mínimos requeridos:
+- `minutes.view`
+- `minutes.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/minutes/config.php
+++ b/modules/minutes/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Minutes',
+        'permissions' => ['minutes.view', 'minutes.edit']
+    ]
+];

--- a/modules/minutes/controller.php
+++ b/modules/minutes/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Minutes module API controller
+/**
+ * Controlador API del módulo Minutes
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['minutes.view', 'minutes.edit'],
+        'user'  => ['minutes.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/minutes/index.php
+++ b/modules/minutes/index.php
@@ -1,5 +1,31 @@
 <?php
-// Minutes module main view
+/**
+ * Módulo Minutes - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['minutes.view', 'minutes.edit'],
+        'user'  => ['minutes.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/minutes/modals.php
+++ b/modules/minutes/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Minutes
+?>

--- a/modules/petty-cash/README.md
+++ b/modules/petty-cash/README.md
@@ -1,0 +1,7 @@
+# Módulo Petty Cash
+
+Permisos mínimos requeridos:
+- `petty-cash.view`
+- `petty-cash.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/petty-cash/config.php
+++ b/modules/petty-cash/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Petty Cash',
+        'permissions' => ['petty-cash.view', 'petty-cash.edit']
+    ]
+];

--- a/modules/petty-cash/controller.php
+++ b/modules/petty-cash/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Petty Cash module API controller
+/**
+ * Controlador API del módulo Petty Cash
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['petty-cash.view', 'petty-cash.edit'],
+        'user'  => ['petty-cash.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/petty-cash/index.php
+++ b/modules/petty-cash/index.php
@@ -1,5 +1,31 @@
 <?php
-// Petty Cash module main view
+/**
+ * Módulo Petty Cash - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['petty-cash.view', 'petty-cash.edit'],
+        'user'  => ['petty-cash.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/petty-cash/modals.php
+++ b/modules/petty-cash/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Petty Cash
+?>

--- a/modules/pos/README.md
+++ b/modules/pos/README.md
@@ -1,0 +1,7 @@
+# Módulo Pos
+
+Permisos mínimos requeridos:
+- `pos.view`
+- `pos.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/pos/config.php
+++ b/modules/pos/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Pos',
+        'permissions' => ['pos.view', 'pos.edit']
+    ]
+];

--- a/modules/pos/controller.php
+++ b/modules/pos/controller.php
@@ -1,5 +1,41 @@
 <?php
-// POS module API controller
+/**
+ * Controlador API del módulo Pos
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['pos.view', 'pos.edit'],
+        'user'  => ['pos.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/pos/index.php
+++ b/modules/pos/index.php
@@ -1,5 +1,31 @@
 <?php
-// Point of Sale (POS) module main view
+/**
+ * Módulo Pos - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['pos.view', 'pos.edit'],
+        'user'  => ['pos.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/pos/modals.php
+++ b/modules/pos/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Pos
+?>

--- a/modules/processes-tasks/README.md
+++ b/modules/processes-tasks/README.md
@@ -754,3 +754,7 @@ INSERT INTO workflow_templates (name, description, category, department_id, temp
 ---
 
 **🚀 ¡Listo para implementar! El módulo sigue el patrón establecido y está preparado para integrarse perfectamente con el ecosistema SaaS existente.**
+
+---
+
+Para más información sobre roles y permisos, consulta [docs/roles_permisos.md](../../docs/roles_permisos.md).

--- a/modules/properties/README.md
+++ b/modules/properties/README.md
@@ -1,0 +1,7 @@
+# Módulo Properties
+
+Permisos mínimos requeridos:
+- `properties.view`
+- `properties.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/properties/config.php
+++ b/modules/properties/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Properties',
+        'permissions' => ['properties.view', 'properties.edit']
+    ]
+];

--- a/modules/properties/controller.php
+++ b/modules/properties/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Properties module API controller
+/**
+ * Controlador API del módulo Properties
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['properties.view', 'properties.edit'],
+        'user'  => ['properties.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/properties/index.php
+++ b/modules/properties/index.php
@@ -1,5 +1,31 @@
 <?php
-// Properties module main view
+/**
+ * Módulo Properties - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['properties.view', 'properties.edit'],
+        'user'  => ['properties.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/properties/modals.php
+++ b/modules/properties/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Properties
+?>

--- a/modules/sales-agent/README.md
+++ b/modules/sales-agent/README.md
@@ -1,0 +1,7 @@
+# Módulo Sales Agent
+
+Permisos mínimos requeridos:
+- `sales-agent.view`
+- `sales-agent.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/sales-agent/config.php
+++ b/modules/sales-agent/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Sales Agent',
+        'permissions' => ['sales-agent.view', 'sales-agent.edit']
+    ]
+];

--- a/modules/sales-agent/controller.php
+++ b/modules/sales-agent/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Sales Agent (AI) module API controller
+/**
+ * Controlador API del módulo Sales Agent
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['sales-agent.view', 'sales-agent.edit'],
+        'user'  => ['sales-agent.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/sales-agent/index.php
+++ b/modules/sales-agent/index.php
@@ -1,5 +1,31 @@
 <?php
-// Sales Agent (AI) module main view
+/**
+ * Módulo Sales Agent - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['sales-agent.view', 'sales-agent.edit'],
+        'user'  => ['sales-agent.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/sales-agent/modals.php
+++ b/modules/sales-agent/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Sales Agent
+?>

--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -1,0 +1,7 @@
+# Módulo Settings
+
+Permisos mínimos requeridos:
+- `settings.view`
+- `settings.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/settings/config.php
+++ b/modules/settings/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Settings',
+        'permissions' => ['settings.view', 'settings.edit']
+    ]
+];

--- a/modules/settings/controller.php
+++ b/modules/settings/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Settings module API controller
+/**
+ * Controlador API del módulo Settings
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['settings.view', 'settings.edit'],
+        'user'  => ['settings.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/settings/index.php
+++ b/modules/settings/index.php
@@ -1,5 +1,31 @@
 <?php
-// Settings module main view
+/**
+ * Módulo Settings - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['settings.view', 'settings.edit'],
+        'user'  => ['settings.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/settings/modals.php
+++ b/modules/settings/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Settings
+?>

--- a/modules/template-module/README.md
+++ b/modules/template-module/README.md
@@ -1,0 +1,7 @@
+# Módulo Template Module
+
+Permisos mínimos requeridos:
+- `template-module.view`
+- `template-module.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/template-module/config.php
+++ b/modules/template-module/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Template Module',
+        'permissions' => ['template-module.view', 'template-module.edit']
+    ]
+];

--- a/modules/template-module/controller.php
+++ b/modules/template-module/controller.php
@@ -1,35 +1,41 @@
 <?php
-require_once '../../config.php';
-header('Content-Type: application/json');
+/**
+ * Controlador API del módulo Template Module
+ */
 
-// Permission check example
-function hasPermission($action) {
-    // Replace with real permission logic
-    return true;
+require_once '../../config.php';
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
 }
 
-$action = $_REQUEST['action'] ?? '';
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['template-module.view', 'template-module.edit'],
+        'user'  => ['template-module.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
 
 switch ($action) {
-    case 'create':
-        if (!hasPermission('create')) exit(json_encode(['error' => 'No permission']));
-        // ...create logic...
-        exit(json_encode(['success' => true]));
-    case 'edit':
-        if (!hasPermission('edit')) exit(json_encode(['error' => 'No permission']));
-        // ...edit logic...
-        exit(json_encode(['success' => true]));
-    case 'delete':
-        if (!hasPermission('delete')) exit(json_encode(['error' => 'No permission']));
-        // ...delete logic...
-        exit(json_encode(['success' => true]));
-    case 'action':
-        if (!hasPermission('action')) exit(json_encode(['error' => 'No permission']));
-        // ...contextual action logic...
-        exit(json_encode(['success' => true]));
-    case 'list':
-        // ...list logic...
-        exit(json_encode(['data' => []]));
     default:
-        exit(json_encode(['error' => 'Unknown action']));
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
 }
+?>

--- a/modules/template-module/index.php
+++ b/modules/template-module/index.php
@@ -1,38 +1,31 @@
 <?php
+/**
+ * Módulo Template Module - vista principal
+ */
+
 require_once '../../config.php';
-$moduleName = $lang['template_module'] ?? 'Template Module';
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['template-module.view', 'template-module.edit'],
+        'user'  => ['template-module.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo getCurrentLanguage(); ?>">
-<head>
-    <meta charset="UTF-8">
-    <title><?php echo $moduleName; ?></title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-</head>
-<body>
-    <div class="container mt-4">
-        <h1><?php echo $moduleName; ?></h1>
-        <button class="btn btn-primary mb-2" id="btn-new">
-            <i class="fas fa-plus"></i> <?php echo $lang['create'] ?? 'Create'; ?>
-        </button>
-        <table class="table table-bordered" id="mainTable">
-            <thead>
-                <tr>
-                    <th><?php echo $lang['view'] ?? 'View'; ?></th>
-                    <th><?php echo $lang['edit'] ?? 'Edit'; ?></th>
-                    <th><?php echo $lang['delete'] ?? 'Delete'; ?></th>
-                    <th><?php echo $lang['action'] ?? 'Action'; ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <!-- Rows will be loaded via JS -->
-            </tbody>
-        </table>
-    </div>
-    <?php include 'modals.php'; ?>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="js/template-module.js"></script>
-</body>
-</html>

--- a/modules/training/README.md
+++ b/modules/training/README.md
@@ -1,0 +1,7 @@
+# Módulo Training
+
+Permisos mínimos requeridos:
+- `training.view`
+- `training.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/training/config.php
+++ b/modules/training/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Training',
+        'permissions' => ['training.view', 'training.edit']
+    ]
+];

--- a/modules/training/controller.php
+++ b/modules/training/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Training module API controller
+/**
+ * Controlador API del módulo Training
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['training.view', 'training.edit'],
+        'user'  => ['training.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/training/index.php
+++ b/modules/training/index.php
@@ -1,5 +1,31 @@
 <?php
-// Training module main view
+/**
+ * Módulo Training - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['training.view', 'training.edit'],
+        'user'  => ['training.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/training/modals.php
+++ b/modules/training/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Training
+?>

--- a/modules/transportation/README.md
+++ b/modules/transportation/README.md
@@ -1,0 +1,7 @@
+# Módulo Transportation
+
+Permisos mínimos requeridos:
+- `transportation.view`
+- `transportation.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/transportation/config.php
+++ b/modules/transportation/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Transportation',
+        'permissions' => ['transportation.view', 'transportation.edit']
+    ]
+];

--- a/modules/transportation/controller.php
+++ b/modules/transportation/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Transportation module API controller
+/**
+ * Controlador API del módulo Transportation
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['transportation.view', 'transportation.edit'],
+        'user'  => ['transportation.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/transportation/index.php
+++ b/modules/transportation/index.php
@@ -1,5 +1,31 @@
 <?php
-// Transportation module main view
+/**
+ * Módulo Transportation - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['transportation.view', 'transportation.edit'],
+        'user'  => ['transportation.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/transportation/modals.php
+++ b/modules/transportation/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Transportation
+?>

--- a/modules/vehicles/README.md
+++ b/modules/vehicles/README.md
@@ -1,0 +1,7 @@
+# Módulo Vehicles
+
+Permisos mínimos requeridos:
+- `vehicles.view`
+- `vehicles.edit`
+
+Consulta la [tabla de roles y permisos](../../docs/roles_permisos.md) para más detalles.

--- a/modules/vehicles/config.php
+++ b/modules/vehicles/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'module' => [
+        'name' => 'Vehicles',
+        'permissions' => ['vehicles.view', 'vehicles.edit']
+    ]
+];

--- a/modules/vehicles/controller.php
+++ b/modules/vehicles/controller.php
@@ -1,5 +1,41 @@
 <?php
-// Vehicles module API controller
+/**
+ * Controlador API del módulo Vehicles
+ */
+
 require_once '../../config.php';
-// ...API logic...
+
+if (!checkAuth()) {
+    http_response_code(401);
+    echo json_encode(['error' => 'No autorizado']);
+    exit();
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['vehicles.view', 'vehicles.edit'],
+        'user'  => ['vehicles.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+$db = getDB();
+$action = $_POST['action'] ?? $_GET['action'] ?? '';
+
+switch ($action) {
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Acción no válida']);
+        break;
+}
 ?>

--- a/modules/vehicles/index.php
+++ b/modules/vehicles/index.php
@@ -1,5 +1,31 @@
 <?php
-// Vehicles module main view
+/**
+ * Módulo Vehicles - vista principal
+ */
+
 require_once '../../config.php';
-// ...module logic...
+
+if (!checkAuth()) {
+    redirect('auth/');
+}
+
+function hasPermission($permission) {
+    if (!checkAuth()) {
+        return false;
+    }
+
+    $role = $_SESSION['current_role'] ?? 'user';
+    if (in_array($role, ['root', 'superadmin'])) {
+        return true;
+    }
+
+    $permission_map = [
+        'admin' => ['vehicles.view', 'vehicles.edit'],
+        'user'  => ['vehicles.view']
+    ];
+
+    return in_array($permission, $permission_map[$role] ?? []);
+}
+
+// Contenido del módulo...
 ?>

--- a/modules/vehicles/modals.php
+++ b/modules/vehicles/modals.php
@@ -1,0 +1,3 @@
+<?php
+// Modales del módulo Vehicles
+?>


### PR DESCRIPTION
## Summary
- standardize module index and controller with auth checks and role-based permissions
- add base config and modal templates for modules
- document required permissions linking to roles_permisos

## Testing
- `find modules -maxdepth 2 -name '*.php' ! -name 'controller_clean.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a748960ae8833291989669a6578f7b