### PR TITLE
Implement CSRF protection across application

### DIFF
--- a/admin/accept_invitation.php
+++ b/admin/accept_invitation.php
@@ -195,7 +195,8 @@ if ($token) {
                     </div>
 
                     <!-- Formulario -->
-                    <form id="acceptInvitationForm">
+                    <form>
+    <?php echo csrf_input(); ?>
                         <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
                         
                         <?php if (!$existing_user): ?>

--- a/admin/controller.php
+++ b/admin/controller.php
@@ -5,6 +5,13 @@
  */
 
 require_once '../config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
 require_once 'permissions_manager.php';
 require_once 'db_connection.php';
 // email_config.php ya está incluido desde config.php

--- a/admin/email_settings.php
+++ b/admin/email_settings.php
@@ -183,7 +183,8 @@ function testEmailConfiguration($test_email) {
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <form method="POST">
+                                <form>
+    <?php echo csrf_input(); ?>
                                     <input type="hidden" name="action" value="save_config">
                                     
                                     <div class="row mb-3">
@@ -282,7 +283,8 @@ function testEmailConfiguration($test_email) {
                                 </h5>
                             </div>
                             <div class="card-body">
-                                <form method="POST">
+                                <form>
+    <?php echo csrf_input(); ?>
                                     <input type="hidden" name="action" value="test_email">
                                     <div class="mb-3">
                                         <label class="form-label">Email de Prueba</label>

--- a/admin/modals/edit_user_modal.php
+++ b/admin/modals/edit_user_modal.php
@@ -9,7 +9,8 @@
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <form id="editUserForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <input type="hidden" id="editUserId" name="user_id">
                     
                     <div class="row">

--- a/admin/modals/invite_user_modal.php
+++ b/admin/modals/invite_user_modal.php
@@ -9,7 +9,8 @@
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <form id="inviteUserForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="row">
                         <div class="col-md-6">
                             <div class="mb-3">

--- a/apply_optimizations.php
+++ b/apply_optimizations.php
@@ -54,7 +54,8 @@ header('Content-Type: text/html; charset=UTF-8');
                             <p class="mb-0"><strong>Se recomienda realizar un backup antes de continuar.</strong></p>
                         </div>
                         
-                        <form method="POST">
+                        <form>
+    <?php echo csrf_input(); ?>
                             <div class="form-check mb-3">
                                 <input class="form-check-input" type="checkbox" id="backup_confirm" required>
                                 <label class="form-check-label" for="backup_confirm">

--- a/auth/index.php
+++ b/auth/index.php
@@ -119,7 +119,8 @@ if ($_POST) {
                             </div>
                         <?php endif; ?>
                         
-                        <form method="POST" action="">
+                        <form>
+    <?php echo csrf_input(); ?>
                             <div class="mb-3">
                                 <label for="email" class="form-label">
                                     <i class="fas fa-envelope me-1"></i><?php echo $lang['email']; ?>

--- a/auth/register.php
+++ b/auth/register.php
@@ -133,7 +133,8 @@ if ($_POST) {
                             </div>
                         <?php endif; ?>
                         
-                        <form method="POST" action="">
+                        <form>
+    <?php echo csrf_input(); ?>
                             <!-- Selector de tipo de cuenta -->
                             <div class="mb-4">
                                 <label class="form-label">Tipo de Cuenta *</label>

--- a/businesses/controller.php
+++ b/businesses/controller.php
@@ -1,5 +1,12 @@
 <?php
 require_once '../config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
 require_once '../includes/plan_restrictions.php';
 
 header('Content-Type: application/json');

--- a/businesses/index.php
+++ b/businesses/index.php
@@ -250,7 +250,8 @@ try {
                     <h5 class="modal-title"><?php echo $lang['new_business']; ?></h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <form id="createBusinessForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <input type="hidden" name="unit_id" value="<?php echo $unit_id; ?>">
                     <div class="modal-body">
                         <div class="mb-3">

--- a/companies/check_tables.php
+++ b/companies/check_tables.php
@@ -94,7 +94,8 @@ header('Content-Type: text/html; charset=UTF-8');
                                         echo "<div class='alert alert-danger mt-3'>❌ Error: " . htmlspecialchars($e->getMessage()) . "</div>";
                                     }
                                 } else {
-                                    echo "<form method='POST' class='mt-3'>";
+                                    echo "<form>
+    <?php echo csrf_input(); ?>";
                                     echo "<button type='submit' name='create_user_companies' class='btn btn-warning'>";
                                     echo "<i class='fas fa-plus me-2'></i>Crear tabla user_companies";
                                     echo "</button>";
@@ -150,7 +151,8 @@ header('Content-Type: text/html; charset=UTF-8');
                                         echo "<div class='alert alert-danger mt-3'>❌ Error: " . htmlspecialchars($e->getMessage()) . "</div>";
                                     }
                                 } else {
-                                    echo "<form method='POST' class='mt-3'>";
+                                    echo "<form>
+    <?php echo csrf_input(); ?>";
                                     echo "<button type='submit' name='create_user_invitations' class='btn btn-danger'>";
                                     echo "<i class='fas fa-plus me-2'></i>Crear tabla user_invitations";
                                     echo "</button>";

--- a/companies/controller.php
+++ b/companies/controller.php
@@ -1,6 +1,13 @@
 <?php
 require_once '../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 // Verificar autenticación
 if (!checkAuth()) {
     if (isset($_POST['action'])) {
@@ -97,8 +104,7 @@ try {
             
             // API JSON original para otras acciones
             header('Content-Type: application/json');
-                'company_id' => $company_id
-            ]);
+            echo json_encode(['error' => 'Acción no válida']);
             break;
             
         case 'PUT':

--- a/companies/index.php
+++ b/companies/index.php
@@ -472,7 +472,8 @@ if (!isset($lang) || !is_array($lang)) {
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <form id="createCompanyForm" action="controller.php" method="POST">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="modal-body">
                         <input type="hidden" name="action" value="create_company">
                         
@@ -515,7 +516,8 @@ if (!isset($lang) || !is_array($lang)) {
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <form id="inviteUserForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="modal-body">
                         <div class="mb-3">
                             <label for="inviteEmail" class="form-label">

--- a/companies/index_original.php
+++ b/companies/index_original.php
@@ -221,7 +221,8 @@ try {
                     <h5 class="modal-title"><?php echo $lang['new_company']; ?></h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <form id="createCompanyForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="modal-body">
                         <div class="mb-3">
                             <label for="company_name" class="form-label"><?php echo $lang['company_name']; ?> *</label>

--- a/companies/invitations.php
+++ b/companies/invitations.php
@@ -197,7 +197,8 @@ $page_title = "Gestionar Invitaciones";
                     <h5 class="modal-title">Nueva Invitación</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <form id="inviteForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="modal-body">
                         <div class="mb-3">
                             <label for="email" class="form-label">Email del Usuario *</label>

--- a/config.php
+++ b/config.php
@@ -22,6 +22,7 @@ loadEnv();
 // Rutas base del sistema
 define('BASE_PATH', __DIR__);
 define('BASE_URL', '/');
+require_once BASE_PATH . '/includes/csrf.php';
 
 // Configuración de zona horaria
 date_default_timezone_set('America/Mexico_City');

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,0 +1,22 @@
+<?php
+// CSRF helper functions
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function csrf_input() {
+    return '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8') . '">';
+}
+
+function verify_csrf() {
+    $token = $_POST['csrf_token'] ?? '';
+    return !empty($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}
+?>

--- a/modules/analytics/controller.php
+++ b/modules/analytics/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/chat/controller.php
+++ b/modules/chat/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/cleaning/controller.php
+++ b/modules/cleaning/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/crm/controller.php
+++ b/modules/crm/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/expenses/controller.php
+++ b/modules/expenses/controller.php
@@ -6,6 +6,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 // Verificar autenticación
 if (!checkAuth()) {
     http_response_code(401);

--- a/modules/expenses/fix_providers.php
+++ b/modules/expenses/fix_providers.php
@@ -129,7 +129,8 @@ try {
     // Test rápido de creación
     echo "<div style='background: #f8f9fa; padding: 15px; margin: 10px 0; border-radius: 5px;'>";
     echo "<h4>🧪 Crear Proveedor de Prueba:</h4>";
-    echo '<form method="POST" style="margin-top: 10px;">';
+    echo '<form>
+    <?php echo csrf_input(); ?>';
     echo '<div style="margin-bottom: 10px;">';
     echo '<input type="text" name="test_name" placeholder="Nombre del proveedor" required style="margin-right: 10px; padding: 8px; width: 200px;">';
     echo '<input type="email" name="test_email" placeholder="Email (opcional)" style="margin-right: 10px; padding: 8px; width: 200px;">';

--- a/modules/expenses/index.php
+++ b/modules/expenses/index.php
@@ -312,7 +312,8 @@ $units = $stmt->fetchAll();
     <!-- Filtros -->
     <div class="card filters-section mb-4">
         <div class="card-body">
-            <form method="GET" id="filterForm" class="row g-3">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="col-md-3">
                     <label class="form-label">Proveedor</label>
                     <select name="proveedor_id" class="form-select select2">

--- a/modules/expenses/index_complete.php
+++ b/modules/expenses/index_complete.php
@@ -290,7 +290,8 @@ $units = $stmt->fetchAll();
     <!-- Filtros -->
     <div class="card filters-section mb-4">
         <div class="card-body">
-            <form method="GET" id="filterForm" class="row g-3">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="col-md-3">
                     <label class="form-label">Proveedor</label>
                     <select name="proveedor" class="form-select select2">

--- a/modules/expenses/modals.php
+++ b/modules/expenses/modals.php
@@ -42,7 +42,8 @@ if (!$company_id) {
                 <h5 class="modal-title" id="expenseModalLabel">Nuevo Gasto</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="expenseForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <input type="hidden" id="expense_id_hidden" name="expense_id">
                     
@@ -181,7 +182,8 @@ if (!$company_id) {
                 <h5 class="modal-title" id="editExpenseModalLabel">Editar Gasto</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="editExpenseForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <input type="hidden" id="edit_expense_id" name="expense_id">
                     
@@ -310,7 +312,8 @@ if (!$company_id) {
                 <h5 class="modal-title" id="paymentModalLabel">Registrar Pago</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="paymentForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <input type="hidden" id="payment_expense_id" name="expense_id">
                     
@@ -385,7 +388,8 @@ if (!$company_id) {
                 <h5 class="modal-title" id="providerModalLabel">Nuevo Proveedor</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="providerForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <input type="hidden" id="provider_id_hidden" name="provider_id">
                     
@@ -436,7 +440,8 @@ if (!$company_id) {
                 <h5 class="modal-title" id="orderModalLabel">Nueva Orden de Compra</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="orderForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-md-6">

--- a/modules/forms/controller.php
+++ b/modules/forms/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/human-resources/controller.php
+++ b/modules/human-resources/controller.php
@@ -6,6 +6,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 // Verificar autenticación
 if (!checkAuth()) {
     http_response_code(401);

--- a/modules/human-resources/index.php
+++ b/modules/human-resources/index.php
@@ -377,7 +377,8 @@ $positions = $stmt->fetchAll();
         </div>
         <div class="collapse show" id="filtrosCollapse">
             <div class="card-body">
-                <form method="GET" class="row g-3">
+                <form>
+    <?php echo csrf_input(); ?>
                     <div class="col-md-3">
                         <label class="form-label">Departamento</label>
                         <select name="department_id" class="form-select">

--- a/modules/human-resources/modals.php
+++ b/modules/human-resources/modals.php
@@ -15,7 +15,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <form id="employeeForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <!-- Tabs Navigation -->
                     <ul class="nav nav-tabs mb-4" id="employeeTabs" role="tablist">
@@ -557,7 +558,8 @@
                     </ul>
                     <hr>
                     <h6 class="mb-3">Crear nuevo puesto</h6>
-                    <form id="formNewPosition">
+                    <form>
+    <?php echo csrf_input(); ?>
                         <div class="mb-3">
                             <label for="positionName" class="form-label">Nombre del Puesto</label>
                             <input type="text" class="form-control" id="positionName" name="positionName" placeholder="Ejemplo: Analista de Datos" required>

--- a/modules/inventory/controller.php
+++ b/modules/inventory/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/invoicing/controller.php
+++ b/modules/invoicing/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/kpis/controller.php
+++ b/modules/kpis/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/laundry/controller.php
+++ b/modules/laundry/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/maintenance/controller.php
+++ b/modules/maintenance/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/maintenance/modals.php
+++ b/modules/maintenance/modals.php
@@ -1,6 +1,7 @@
 <div class="modal fade" id="completeModal" tabindex="-1" aria-labelledby="completeModalLabel" aria-hidden="true">
   <div class="modal-dialog">
-    <form class="modal-content" id="completeForm">
+    <form>
+    <?php echo csrf_input(); ?>
       <div class="modal-header">
         <h5 class="modal-title" id="completeModalLabel"><?php echo $lang['complete_service'] ?? 'Complete Service'; ?></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/modules/minutes/controller.php
+++ b/modules/minutes/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/petty-cash/controller.php
+++ b/modules/petty-cash/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/pos/controller.php
+++ b/modules/pos/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/processes-tasks/controller.php
+++ b/modules/processes-tasks/controller.php
@@ -5,6 +5,13 @@
  */
 
 require_once '../../config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
 header('Content-Type: application/json; charset=utf-8');
 
 // Verificar autenticación

--- a/modules/processes-tasks/modals.php
+++ b/modules/processes-tasks/modals.php
@@ -9,7 +9,8 @@
 <div class="modal fade" id="newProcessModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="newProcessForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-header">
                     <h5 class="modal-title">
                         <i class="fas fa-plus text-primary me-2"></i>
@@ -82,7 +83,8 @@
 <div class="modal fade" id="editProcessModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="editProcessForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" name="process_id" id="editProcessId">
                 <div class="modal-header">
                     <h5 class="modal-title">
@@ -154,7 +156,8 @@
 <div class="modal fade" id="newTaskModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="newTaskForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-header">
                     <h5 class="modal-title">
                         <i class="fas fa-plus text-success me-2"></i>
@@ -233,7 +236,8 @@
 <div class="modal fade" id="editTaskModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="editTaskForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" name="task_id" id="editTaskId">
                 <div class="modal-header">
                     <h5 class="modal-title">
@@ -311,7 +315,8 @@
 <div class="modal fade" id="completeTaskModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="completeTaskForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" name="task_id" id="completeTaskId">
                 <div class="modal-header">
                     <h5 class="modal-title">
@@ -354,7 +359,8 @@
 <div class="modal fade" id="reassignTaskModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="reassignTaskForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" name="task_id" id="reassignTaskId">
                 <div class="modal-header">
                     <h5 class="modal-title">
@@ -398,7 +404,8 @@
 <div class="modal fade" id="bulkAssignModal" tabindex="-1">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <form id="bulkAssignForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-header">
                     <h5 class="modal-title">
                         <i class="fas fa-users text-primary me-2"></i>
@@ -516,7 +523,8 @@
 <div class="modal fade" id="updateProgressModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="updateProgressForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" name="task_id" id="updateProgressTaskId">
                 <div class="modal-header">
                     <h5 class="modal-title">

--- a/modules/properties/controller.php
+++ b/modules/properties/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/sales-agent/controller.php
+++ b/modules/sales-agent/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/settings/controller.php
+++ b/modules/settings/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/template-module/controller.php
+++ b/modules/template-module/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/template-module/modals.php
+++ b/modules/template-module/modals.php
@@ -1,6 +1,7 @@
 <div class="modal fade" id="modalForm" tabindex="-1" aria-labelledby="modalFormLabel" aria-hidden="true">
   <div class="modal-dialog">
-    <form class="modal-content" id="modalForm">
+    <form>
+    <?php echo csrf_input(); ?>
       <div class="modal-header">
         <h5 class="modal-title" id="modalFormLabel">Modal Form (Contextual)</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/modules/training/controller.php
+++ b/modules/training/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/transportation/controller.php
+++ b/modules/transportation/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/modules/vehicles/controller.php
+++ b/modules/vehicles/controller.php
@@ -5,6 +5,13 @@
 
 require_once '../../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 if (!checkAuth()) {
     http_response_code(401);
     echo json_encode(['error' => 'No autorizado']);

--- a/notifications/index.php
+++ b/notifications/index.php
@@ -151,7 +151,8 @@ $page_title = "Notificaciones";
                                         </small>
                                     </div>
                                     <div class="ms-3">
-                                        <form method="POST" class="d-inline">
+                                        <form>
+    <?php echo csrf_input(); ?>
                                             <input type="hidden" name="notification_id" value="<?php echo $invitation['id']; ?>">
                                             <button type="submit" name="accept_invitation" class="btn btn-success btn-sm">
                                                 <i class="fas fa-check"></i> Aceptar Invitación
@@ -210,7 +211,8 @@ $page_title = "Notificaciones";
                                         </div>
                                         <div class="ms-3">
                                             <?php if ($isUnread): ?>
-                                                <form method="POST" class="d-inline">
+                                                <form>
+    <?php echo csrf_input(); ?>
                                                     <input type="hidden" name="notification_id" value="<?php echo $notification['id']; ?>">
                                                     <button type="submit" name="mark_read" class="btn btn-outline-secondary btn-sm">
                                                         <i class="fas fa-check"></i> Marcar como leída

--- a/panel_root/controller.php
+++ b/panel_root/controller.php
@@ -5,6 +5,13 @@
  */
 
 require_once '../config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
 header('Content-Type: application/json');
 
 // Verificar autenticación y permisos de root

--- a/panel_root/modals/modal_add_module.php
+++ b/panel_root/modals/modal_add_module.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="addModuleForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-md-8">

--- a/panel_root/modals/modal_add_plan.php
+++ b/panel_root/modals/modal_add_plan.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="addPlanForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-md-6">

--- a/panel_root/modals/modal_add_user.php
+++ b/panel_root/modals/modal_add_user.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="addUserForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-md-6">

--- a/panel_root/modals/modal_change_plan.php
+++ b/panel_root/modals/modal_change_plan.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="changePlanForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" id="change_plan_company_id" name="company_id">
                 <div class="modal-body">
                     <div class="alert alert-info">

--- a/panel_root/modals/modal_edit_company.php
+++ b/panel_root/modals/modal_edit_company.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="editCompanyForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" id="edit_company_id" name="id">
                 <div class="modal-body">
                     <div class="row">

--- a/panel_root/modals/modal_edit_module.php
+++ b/panel_root/modals/modal_edit_module.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="editModuleForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" id="editModuleId" name="module_id">
                 <div class="modal-body">
                     <div class="row">

--- a/panel_root/modals/modal_edit_plan.php
+++ b/panel_root/modals/modal_edit_plan.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="editPlanForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" id="edit_id" name="id">
                 <div class="modal-body">
                     <div class="row">

--- a/panel_root/modals/modal_edit_user.php
+++ b/panel_root/modals/modal_edit_user.php
@@ -9,7 +9,8 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form id="editUserForm">
+            <form>
+    <?php echo csrf_input(); ?>
                 <input type="hidden" id="editUserId" name="user_id">
                 <div class="modal-body">
                     <div class="row">

--- a/panel_root/modals/modal_manage_user_roles.php
+++ b/panel_root/modals/modal_manage_user_roles.php
@@ -80,7 +80,8 @@
                         </h6>
                     </div>
                     <div class="card-body" id="newCompanyAssignmentSection" style="display: none;">
-                        <form id="newCompanyRoleForm">
+                        <form>
+    <?php echo csrf_input(); ?>
                             <div class="row">
                                 <div class="col-md-6">
                                     <div class="mb-3">

--- a/profile.php
+++ b/profile.php
@@ -165,7 +165,8 @@ try {
             </div>
         <?php endif; ?>
 
-        <form method="POST" class="row">
+        <form>
+    <?php echo csrf_input(); ?>
             <!-- Información Básica -->
             <div class="col-lg-6 mb-4">
                 <div class="card border-0 shadow-sm h-100">

--- a/units/controller.php
+++ b/units/controller.php
@@ -1,6 +1,13 @@
 <?php
 require_once '../config.php';
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !verify_csrf()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Token CSRF inválido']);
+    exit();
+}
+
+
 header('Content-Type: application/json');
 
 // Verificar autenticación

--- a/units/index.php
+++ b/units/index.php
@@ -215,7 +215,8 @@ try {
                     <h5 class="modal-title"><?php echo $lang['new_unit']; ?></h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
-                <form id="createUnitForm">
+                <form>
+    <?php echo csrf_input(); ?>
                     <input type="hidden" name="company_id" value="<?php echo $company_id; ?>">
                     <div class="modal-body">
                         <div class="mb-3">


### PR DESCRIPTION
## Summary
- Add `includes/csrf.php` helper to generate and verify CSRF tokens
- Inject hidden CSRF field into all forms via `csrf_input()`
- Enforce token validation in every controller before processing POST data

## Testing
- `git status --short`
- `git status --short | awk '{print $2}' | xargs -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a75ffa46dc8332ad442602d6d1a062