### PR TITLE
chore: add PHP_CodeSniffer linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction
+      - name: Run PHP_CodeSniffer
+        run: composer lint

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="Indice SaaS">
+    <description>Project coding standards.</description>
+    <rule ref="PSR12"/>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
         "phpoffice/phpspreadsheet": "^1.29"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10"
+        "phpunit/phpunit": "^10",
+        "squizlabs/php_codesniffer": "^3.13"
+    },
+    "scripts": {
+        "lint": "phpcs modules admin *.php"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "658ca67f44209e74b39d0d5f42b8dc3d",
+    "content-hash": "aade314dba3df2f58c5df21d82c71007",
     "packages": [
         {
             "name": "composer/pcre",
@@ -2610,6 +2610,90 @@
                 }
             ],
             "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribuir
+
+Este proyecto utiliza [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) para mantener un estilo de código consistente.
+
+## Instalación
+
+```bash
+composer install
+```
+
+## Linter
+
+Ejecuta el linter antes de hacer un commit:
+
+```bash
+composer lint
+```
+
+Esto analizará los directorios `modules/`, `admin/` y todos los archivos `*.php` en la raíz del repositorio.
+
+## Integración continua
+
+El flujo de CI ejecuta el mismo comando `composer lint` en cada *push* y *pull request*. Asegúrate de que el comando pase sin errores antes de abrir un PR.


### PR DESCRIPTION
## Summary
- add PHP_CodeSniffer and lint script via Composer
- document lint workflow in docs/CONTRIBUTING.md
- run lint in CI

## Testing
- `composer lint` *(fails: style violations)*
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a7642e25a08332944593b74d60e23b