### PR TITLE
Add CI workflow with lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction
+      - name: Run linters
+        run: composer lint
+      - name: Run unit tests
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- Add CI workflow that installs dependencies, runs PHPCS linter, and executes PHPUnit tests

## Testing
- `composer install --no-progress --no-interaction`
- `composer lint -- --report=summary`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a7667abfc083328fbf782080fdcd95