### PR TITLE
Añade verificación CSRF en login y registro

### DIFF
--- a/auth/index.php
+++ b/auth/index.php
@@ -10,6 +10,8 @@ if (checkAuth()) {
 $error = '';
 $success = '';
 
+if ($_POST && !verify_csrf()) { http_response_code(403); exit; }
+
 if ($_POST) {
     $email = trim($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';

--- a/auth/register.php
+++ b/auth/register.php
@@ -4,6 +4,8 @@ require_once '../config.php';
 $error = '';
 $success = '';
 
+if ($_POST && !verify_csrf()) { http_response_code(403); exit; }
+
 if ($_POST) {
     $name = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');


### PR DESCRIPTION
## Resumen
- Añade verificación CSRF antes de procesar los formularios de inicio de sesión y registro.

## Pruebas
- `php -l auth/index.php`
- `php -l auth/register.php`
- `./vendor/bin/phpunit`
- `php -S 127.0.0.1:8000 &` `curl -i -X POST -d "email=test@example.com" http://127.0.0.1:8000/auth/index.php`
- `php -S 127.0.0.1:8000 &` `curl -i -X POST -d "email=test@example.com" http://127.0.0.1:8000/auth/register.php`


------
https://chatgpt.com/codex/tasks/task_e_68a77689f36c83329334be361e06617e