### PR TITLE
Regenerate session ID after login

### DIFF
--- a/auth/index.php
+++ b/auth/index.php
@@ -24,8 +24,9 @@ if ($_POST) {
             $stmt = $db->prepare("SELECT id, email, password, name, status FROM users WHERE email = ? AND status = 'active'");
             $stmt->execute([$email]);
             $user = $stmt->fetch();
-            
+
             if ($user && password_verify($password, $user['password'])) {
+                session_regenerate_id(true);
                 $_SESSION['user_id'] = $user['id'];
                 $_SESSION['user_name'] = $user['name'];
                 $_SESSION['user_email'] = $user['email'];


### PR DESCRIPTION
## Summary
- Regenerate session ID after validating user credentials in auth login flow to prevent fixation attacks

## Testing
- `./vendor/bin/phpunit`
- `php -r 'session_start(); $old=session_id(); session_regenerate_id(true); $new=session_id(); echo "old=$old\nnew=$new\n";'`

------
https://chatgpt.com/codex/tasks/task_e_68a786f0486c83328b145ce05341481d