### PR TITLE
Add CI workflow for PHP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
 
 jobs:
@@ -14,7 +13,7 @@ jobs:
         with:
           php-version: '8.2'
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction
+        run: composer install
       - name: Run linters
         run: composer lint
       - name: Run unit tests


### PR DESCRIPTION
## Summary
- run composer install, lint and PHPUnit via GitHub Actions

## Testing
- `composer install`
- `composer lint` *(fails: Script phpcs modules admin *.php handling the lint event returned with error code 2)*
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a88f41b5f48332a2ce519bd9d31f14