### PR TITLE
docs: add installation guide and link

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,45 @@
+# Guía de Instalación
+
+## Variables de entorno necesarias
+Copia el archivo `.env.example` a `.env` y ajusta las siguientes variables:
+
+```bash
+DB_HOST=localhost
+DB_NAME=tu_base_de_datos
+DB_USER=tu_usuario
+DB_PASS=tu_contraseña
+
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=tu_email@gmail.com
+MAIL_PASSWORD=tu_contraseña_de_aplicacion
+MAIL_ENCRYPTION=tls
+
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://tudominio.com
+
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+
+CACHE_DRIVER=file
+CACHE_PREFIX=indice_saas_
+```
+
+## Instalación de dependencias
+Ejecuta los siguientes comandos en la raíz del proyecto:
+
+```bash
+composer install
+npm install    # si el proyecto requiere recursos de Node.js
+```
+
+## Verificación rápida
+Confirma que tu entorno cumple con los requisitos mínimos:
+
+```bash
+php -v
+php -m | grep -i pdo
+```
+
+Debe mostrarse la versión de PHP y las extensiones `PDO` y `pdo_mysql` habilitadas.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Esta guía unifica la documentación previamente distribuida en los archivos `RE
 
 ## Índice de guías
 
+- [Guía de instalación](INSTALL.md)
 - [Auditoría del sistema](AUDITORIA_SISTEMA.md)
 - [Estándar de nombres de base de datos](DATABASE_NAMING_STANDARD.md)
 - [Guía de migraciones de base de datos](README_DATABASE.md)


### PR DESCRIPTION
## Summary
- document required `.env` variables and dependency installation commands
- add quick PHP verification steps
- link installation guide from docs index

## Testing
- `composer install`
- `composer lint` (fails: header blocks must be separated by a single blank line)
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a13239c833285c6873841dd6046