### PR TITLE
Add initial data seeder

### DIFF
--- a/database/seeds/seed_initial_data.php
+++ b/database/seeds/seed_initial_data.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+
+try {
+    $db = getDB();
+} catch (Exception $e) {
+    echo "Error connecting to database: " . $e->getMessage() . "\n";
+    exit(1);
+}
+
+// Create root user if not exists
+$email = 'root@indiceapp.com';
+$defaultPassword = 'root123';
+
+$stmt = $db->prepare("SELECT id FROM users WHERE email = ?");
+$stmt->execute([$email]);
+if (!$stmt->fetch()) {
+    $hash = password_hash($defaultPassword, PASSWORD_DEFAULT);
+    $insertUser = $db->prepare("INSERT INTO users (name, email, password, status) VALUES ('Root User', ?, ?, 'active')");
+    $insertUser->execute([$email, $hash]);
+    echo "Root user created.\n";
+} else {
+    echo "Root user already exists.\n";
+}
+
+// Essential modules list
+$modules = [
+    ['Analytics', 'analytics', '/modules/analytics/', 'fas fa-chart-bar', 'admin'],
+    ['Chat', 'chat', '/modules/chat/', 'fas fa-comments', 'admin,user'],
+    ['Cleaning', 'cleaning', '/modules/cleaning/', 'fas fa-broom', 'admin'],
+    ['CRM', 'crm', '/modules/crm/', 'fas fa-user-tie', 'admin'],
+    ['Expenses', 'expenses', '/modules/expenses/', 'fas fa-coins', 'admin'],
+    ['Settings', 'settings', '/modules/settings/', 'fas fa-cogs', 'admin'],
+    ['Training', 'training', '/modules/training/', 'fas fa-chalkboard-teacher', 'user,admin'],
+    ['Transportation', 'transportation', '/modules/transportation/', 'fas fa-bus', 'admin'],
+    ['Vehicles', 'vehicles', '/modules/vehicles/', 'fas fa-car', 'admin'],
+];
+
+$insertModule = $db->prepare(
+    "INSERT INTO modules (name, slug, url, icon, allowed_roles, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 'active', NOW(), NOW())
+     ON DUPLICATE KEY UPDATE status='active', url=VALUES(url), icon=VALUES(icon), allowed_roles=VALUES(allowed_roles), updated_at=NOW()"
+);
+
+foreach ($modules as $module) {
+    $insertModule->execute($module);
+}
+
+$slugs = array_column($modules, 1);
+$placeholders = implode(',', array_fill(0, count($slugs), '?'));
+$sql = "INSERT IGNORE INTO plan_modules (plan_id, module_id, created_at)
+        SELECT p.id, m.id, NOW()
+        FROM plans p
+        JOIN modules m ON m.slug IN ($placeholders)";
+$stmt = $db->prepare($sql);
+$stmt->execute($slugs);
+
+echo "Seed completed.\n";

--- a/docs/README_DATABASE.md
+++ b/docs/README_DATABASE.md
@@ -31,3 +31,11 @@ Los archivos `.sql` son aplicados automáticamente; los scripts `.php` requieren
    el mismo comando de migración.
 
 El script registrará las migraciones aplicadas en la tabla `migrations` para evitar ejecuciones repetidas.
+
+## Seeds de datos iniciales
+
+Para insertar el usuario **root** y activar los módulos esenciales, ejecuta:
+
+```bash
+php database/seeds/seed_initial_data.php
+```

--- a/scripts/install_all.php
+++ b/scripts/install_all.php
@@ -47,6 +47,7 @@ if ($status !== 0) {
 
 $extraScripts = [
     $root . '/panel_root/create_plans_table.php',
+    $root . '/database/seeds/seed_initial_data.php',
 ];
 
 foreach ($extraScripts as $script) {


### PR DESCRIPTION
## Summary
- seed root user and activate essential modules
- run seed script from install_all
- document manual seed execution

## Testing
- `composer run lint` *(fails: header blocks and spacing issues)*
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ac7ac2841c8332b19181a66b8c9520