### PR TITLE
Add installation smoke test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "squizlabs/php_codesniffer": "^3.13"
     },
     "scripts": {
-        "lint": "phpcs modules admin *.php"
+        "lint": "phpcs modules admin *.php",
+        "test": "phpunit"
     }
 }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -43,3 +43,12 @@ php -m | grep -i pdo
 ```
 
 Debe mostrarse la versión de PHP y las extensiones `PDO` y `pdo_mysql` habilitadas.
+
+## Prueba de instalación
+Ejecuta el test de humo para verificar la conexión a la base de datos y los datos iniciales:
+
+```bash
+composer test
+# o
+vendor/bin/phpunit tests/InstallSmokeTest.php
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,5 +10,8 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Install">
+            <file>tests/InstallSmokeTest.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/InstallSmokeTest.php
+++ b/tests/InstallSmokeTest.php
@@ -1,0 +1,45 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../config.php';
+
+final class InstallSmokeTest extends TestCase
+{
+    private ?PDO $db = null;
+
+    private function db(): PDO
+    {
+        if ($this->db === null) {
+            $dsn = sprintf(
+                'mysql:host=%s;dbname=%s;charset=utf8mb4',
+                $_ENV['DB_HOST'],
+                $_ENV['DB_NAME']
+            );
+            $this->db = new PDO($dsn, $_ENV['DB_USER'], $_ENV['DB_PASS'], [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+        }
+        return $this->db;
+    }
+
+    public function testDatabaseConnection(): void
+    {
+        $this->assertInstanceOf(PDO::class, $this->db());
+    }
+
+    public function testRootUserExists(): void
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM users WHERE email = ?');
+        $stmt->execute(['root@indiceapp.com']);
+        $count = (int) $stmt->fetchColumn();
+        $this->assertGreaterThan(0, $count, 'Root user not found');
+    }
+
+    public function testModulesTableHasRecords(): void
+    {
+        $count = (int) $this->db()->query('SELECT COUNT(*) FROM modules')->fetchColumn();
+        $this->assertGreaterThan(0, $count, 'Modules table is empty');
+    }
+}


### PR DESCRIPTION
## Summary
- add InstallSmokeTest to verify DB connection, root user, and module records
- run smoke test during install docs and add composer test script
- include test in phpunit configuration

## Testing
- `composer install`
- `composer test` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ac7beab3048332b248d41973de7f59